### PR TITLE
claude/web-interface-system-dinOm

### DIFF
--- a/amazon/login.py
+++ b/amazon/login.py
@@ -1,5 +1,4 @@
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
-from gui_utils.gui import prompt_two_factor_code
 
 AMAZON_NOTEBOOK_URL = "https://read.amazon.co.jp/notebook"
 EMAIL_SELECTOR = "#ap_email_login"
@@ -11,7 +10,11 @@ TWO_FACTOR_SUBMIT_SELECTOR = "#auth-signin-button"
 IDLE = "networkidle"
 LOAD_TIMEOUT = 15000
 
-def perform_login(page, amazon_email, amazon_password):
+def perform_login(page, amazon_email, amazon_password, two_factor_callback=None):
+    if two_factor_callback is None:
+        from gui_utils.gui import prompt_two_factor_code
+        two_factor_callback = prompt_two_factor_code
+
     page.goto(AMAZON_NOTEBOOK_URL, timeout=LOAD_TIMEOUT)
     page.fill(EMAIL_SELECTOR, amazon_email)
     page.click(CONTINUE_SELECTOR)
@@ -21,7 +24,7 @@ def perform_login(page, amazon_email, amazon_password):
 
     try:
         page.wait_for_selector(TWO_FACTOR_INPUT_SELECTOR, timeout=LOAD_TIMEOUT)
-        code = prompt_two_factor_code()
+        code = two_factor_callback()
         if code is None:
             raise SystemExit("Cancelled by user during two-factor authentication.")
         page.fill(TWO_FACTOR_INPUT_SELECTOR, code)

--- a/main.py
+++ b/main.py
@@ -8,8 +8,6 @@ from playwright.sync_api import sync_playwright
 
 import amazon.login
 from book_transformer import transformer
-from gui_utils import gui
-from gui_utils.gui import ask_book_limit
 from notion import toNotion
 
 nest_asyncio.apply()
@@ -18,55 +16,80 @@ BASE_DIR = Path(__file__).resolve().parent
 ENV_PATH = BASE_DIR / "config" / "KEYS.env"
 STORAGE_STATE_PATH = BASE_DIR / "storage_state.json"
 
-load_dotenv(ENV_PATH)
-AMAZON_EMAIL = os.getenv("AMAZON_EMAIL")
-AMAZON_PASSWORD = os.getenv("AMAZON_PASSWORD")
-NOTION_API_KEY = os.getenv("NOTION_API_KEY")
-NOTION_DATABASE_ID = os.getenv("NOTION_DATABASE_ID")
-GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE_ENV = os.getenv("GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE")
-GOOGLE_SHEETS_SPREADSHEET_ID = os.getenv("GOOGLE_SHEETS_SPREADSHEET_ID")
-GOOGLE_SHEETS_WORKSHEET_NAME = os.getenv("GOOGLE_SHEETS_WORKSHEET_NAME", "Sheet1")
-
-required_env_vars = [AMAZON_EMAIL, AMAZON_PASSWORD, NOTION_API_KEY, NOTION_DATABASE_ID]
-if not all(required_env_vars):
-    raise ValueError(
-        "Missing required environment variables. Please set AMAZON_EMAIL, AMAZON_PASSWORD, "
-        "NOTION_API_KEY, and NOTION_DATABASE_ID in config/KEYS.env."
-    )
-
-google_sheets_envs = [
-    GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE_ENV,
-    GOOGLE_SHEETS_SPREADSHEET_ID,
-]
-GOOGLE_SHEETS_ENABLED = all(google_sheets_envs)
-if any(google_sheets_envs) and not GOOGLE_SHEETS_ENABLED:
-    raise ValueError(
-        "Incomplete Google Sheets configuration. To enable Google Sheets export, set "
-        "GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE and GOOGLE_SHEETS_SPREADSHEET_ID in config/KEYS.env."
-    )
-
+_config_loaded = False
+AMAZON_EMAIL = None
+AMAZON_PASSWORD = None
+NOTION_API_KEY = None
+NOTION_DATABASE_ID = None
+GOOGLE_SHEETS_ENABLED = False
 GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE = None
-if GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE_ENV:
-    service_account_value = GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE_ENV.strip()
-    if service_account_value.startswith("{"):
-        GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE = service_account_value
-    else:
-        service_account_value = service_account_value.strip("'\"")
-        service_account_path = Path(service_account_value)
-        if not service_account_path.is_absolute():
-            service_account_path = BASE_DIR / service_account_path
-        GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE = str(service_account_path)
+GOOGLE_SHEETS_SPREADSHEET_ID = None
+GOOGLE_SHEETS_WORKSHEET_NAME = "Sheet1"
+
+
+def load_config():
+    """Load and validate configuration from KEYS.env. Safe to call multiple times."""
+    global _config_loaded
+    global AMAZON_EMAIL, AMAZON_PASSWORD, NOTION_API_KEY, NOTION_DATABASE_ID
+    global GOOGLE_SHEETS_ENABLED, GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE
+    global GOOGLE_SHEETS_SPREADSHEET_ID, GOOGLE_SHEETS_WORKSHEET_NAME
+
+    if _config_loaded:
+        return
+
+    load_dotenv(ENV_PATH)
+    AMAZON_EMAIL = os.getenv("AMAZON_EMAIL")
+    AMAZON_PASSWORD = os.getenv("AMAZON_PASSWORD")
+    NOTION_API_KEY = os.getenv("NOTION_API_KEY")
+    NOTION_DATABASE_ID = os.getenv("NOTION_DATABASE_ID")
+    google_sheets_saf_env = os.getenv("GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE")
+    GOOGLE_SHEETS_SPREADSHEET_ID = os.getenv("GOOGLE_SHEETS_SPREADSHEET_ID")
+    GOOGLE_SHEETS_WORKSHEET_NAME = os.getenv("GOOGLE_SHEETS_WORKSHEET_NAME", "Sheet1")
+
+    required_env_vars = [AMAZON_EMAIL, AMAZON_PASSWORD, NOTION_API_KEY, NOTION_DATABASE_ID]
+    if not all(required_env_vars):
+        raise ValueError(
+            "Missing required environment variables. Please set AMAZON_EMAIL, AMAZON_PASSWORD, "
+            "NOTION_API_KEY, and NOTION_DATABASE_ID in config/KEYS.env."
+        )
+
+    google_sheets_envs = [google_sheets_saf_env, GOOGLE_SHEETS_SPREADSHEET_ID]
+    GOOGLE_SHEETS_ENABLED = all(google_sheets_envs)
+    if any(google_sheets_envs) and not GOOGLE_SHEETS_ENABLED:
+        raise ValueError(
+            "Incomplete Google Sheets configuration. To enable Google Sheets export, set "
+            "GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE and GOOGLE_SHEETS_SPREADSHEET_ID in config/KEYS.env."
+        )
+
+    GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE = None
+    if google_sheets_saf_env:
+        service_account_value = google_sheets_saf_env.strip()
+        if service_account_value.startswith("{"):
+            GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE = service_account_value
+        else:
+            service_account_value = service_account_value.strip("'\"")
+            service_account_path = Path(service_account_value)
+            if not service_account_path.is_absolute():
+                service_account_path = BASE_DIR / service_account_path
+            GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE = str(service_account_path)
+
+    _config_loaded = True
+
 
 def prompt_book_limit():
+    from gui_utils.gui import ask_book_limit
     return ask_book_limit()
 
-def run(playwright, max_books=None, progress_callback=None):
-    browser = playwright.chromium.launch(headless=False)
+
+def run(playwright, max_books=None, progress_callback=None,
+        two_factor_callback=None, headless_login=False):
+    browser = playwright.chromium.launch(headless=headless_login)
     context = browser.new_context()
     page = context.new_page()
 
     try:
-        amazon.login.perform_login(page, AMAZON_EMAIL, AMAZON_PASSWORD)
+        amazon.login.perform_login(page, AMAZON_EMAIL, AMAZON_PASSWORD,
+                                   two_factor_callback=two_factor_callback)
         context.storage_state(path=str(STORAGE_STATE_PATH))
     finally:
         browser.close()
@@ -83,6 +106,9 @@ def run(playwright, max_books=None, progress_callback=None):
         headless_browser.close()
 
 if __name__ == "__main__":
+    from gui_utils import gui
+
+    load_config()
     max_books = prompt_book_limit()
     window = gui.ProgressWindow(total_books=max_books)
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,3 +5,4 @@ nest-asyncio
 tqdm
 gspread
 google-auth
+flask

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,113 @@
+import json
+import os
+import threading
+import time
+
+from flask import Flask, Response, jsonify, render_template, request
+
+from web.pipeline import PipelineState, run_pipeline
+
+
+def create_app():
+    app = Flask(__name__)
+
+    # ------------------------------------------------------------------
+    # Shared state (single-user tool — one pipeline at a time)
+    # ------------------------------------------------------------------
+    state = PipelineState()
+    run_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Basic HTTP auth
+    # ------------------------------------------------------------------
+    web_username = os.getenv("WEB_USERNAME", "")
+    web_password = os.getenv("WEB_PASSWORD", "")
+    auth_enabled = bool(web_username and web_password)
+
+    @app.before_request
+    def _check_auth():
+        if not auth_enabled:
+            return None
+        auth = request.authorization
+        if auth and auth.username == web_username and auth.password == web_password:
+            return None
+        return Response(
+            "Unauthorized",
+            401,
+            {"WWW-Authenticate": 'Basic realm="kindle2notion"'},
+        )
+
+    # ------------------------------------------------------------------
+    # Routes
+    # ------------------------------------------------------------------
+
+    @app.route("/")
+    def index():
+        return render_template("index.html")
+
+    @app.route("/api/start", methods=["POST"])
+    def api_start():
+        nonlocal state
+
+        if not run_lock.acquire(blocking=False):
+            return jsonify({"error": "Pipeline is already running."}), 409
+
+        try:
+            body = request.get_json(silent=True) or {}
+            max_books_raw = body.get("max_books")
+            max_books = int(max_books_raw) if max_books_raw else None
+
+            # Reset state for a new run
+            state = PipelineState()
+
+            worker = threading.Thread(
+                target=_run_and_release,
+                args=(state, max_books),
+                daemon=True,
+            )
+            worker.start()
+            return jsonify({"status": "started"})
+        except Exception:
+            run_lock.release()
+            raise
+
+    def _run_and_release(pipeline_state, max_books):
+        try:
+            run_pipeline(pipeline_state, max_books)
+        finally:
+            run_lock.release()
+
+    @app.route("/api/2fa", methods=["POST"])
+    def api_two_factor():
+        body = request.get_json(silent=True) or {}
+        code = (body.get("code") or "").strip()
+        if not code:
+            return jsonify({"error": "Code is required."}), 400
+        state.submit_two_factor(code)
+        return jsonify({"status": "submitted"})
+
+    @app.route("/api/events")
+    def api_events():
+        """Server-Sent Events stream for real-time progress."""
+        def generate():
+            last_index = 0
+            while True:
+                events, new_index = state.get_events_since(last_index)
+                last_index = new_index
+                for event in events:
+                    payload = json.dumps(event["data"], ensure_ascii=False)
+                    yield f"event: {event['type']}\ndata: {payload}\n\n"
+                if state.status in ("done", "error"):
+                    break
+                time.sleep(0.3)
+
+        return Response(generate(), mimetype="text/event-stream",
+                        headers={"Cache-Control": "no-cache",
+                                 "X-Accel-Buffering": "no"})
+
+    @app.route("/api/status")
+    def api_status():
+        """Fallback polling endpoint."""
+        return jsonify({"status": state.status})
+
+    return app

--- a/web/pipeline.py
+++ b/web/pipeline.py
@@ -1,0 +1,117 @@
+import json
+import threading
+import traceback
+
+from playwright.sync_api import sync_playwright
+
+import main
+from notion import toNotion
+
+
+class PipelineState:
+    """Shared state between the pipeline worker thread and Flask routes.
+
+    Pushes SSE-style events that the ``/api/events`` endpoint streams to the
+    browser.  The 2FA bridge uses :class:`threading.Event` so the Playwright
+    thread blocks until the user submits a code via the web form.
+    """
+
+    def __init__(self):
+        self.events = []
+        self.status = "idle"  # idle | running | waiting_2fa | done | error
+        self._lock = threading.Lock()
+        self._two_factor_event = threading.Event()
+        self._two_factor_code = None
+
+    # ------------------------------------------------------------------
+    # 2FA bridge
+    # ------------------------------------------------------------------
+
+    def request_two_factor(self):
+        """Called from the Playwright thread.  Blocks until a code arrives."""
+        self.status = "waiting_2fa"
+        self._push_event("2fa_required", {})
+        self._two_factor_event.clear()
+        self._two_factor_event.wait(timeout=300)  # 5 min
+        code = self._two_factor_code
+        self._two_factor_code = None
+        if code is None:
+            return None
+        self.status = "running"
+        return code
+
+    def submit_two_factor(self, code):
+        """Called from the Flask route when the user submits a 2FA code."""
+        self._two_factor_code = code
+        self._two_factor_event.set()
+
+    # ------------------------------------------------------------------
+    # Progress callback  (drop-in for gui.ProgressWindow.update)
+    # ------------------------------------------------------------------
+
+    def progress_callback(self, phase, current, total, message):
+        self._push_event("progress", {
+            "phase": phase,
+            "current": current,
+            "total": total,
+            "message": message,
+        })
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _push_event(self, event_type, data):
+        with self._lock:
+            self.events.append({"type": event_type, "data": data})
+
+    def get_events_since(self, index):
+        with self._lock:
+            return self.events[index:], len(self.events)
+
+
+def run_pipeline(state, max_books):
+    """Execute the full scrape -> Notion -> Sheets pipeline.
+
+    Intended to run in a background :class:`threading.Thread`.
+    """
+    state.status = "running"
+    state._push_event("started", {})
+
+    try:
+        main.load_config()
+
+        with sync_playwright() as p:
+            notes = main.run(
+                p,
+                max_books=max_books,
+                progress_callback=state.progress_callback,
+                two_factor_callback=state.request_two_factor,
+                headless_login=True,
+            )
+
+        toNotion.save_notes_to_notion(
+            main.NOTION_API_KEY,
+            main.NOTION_DATABASE_ID,
+            notes,
+            progress_callback=state.progress_callback,
+        )
+
+        if main.GOOGLE_SHEETS_ENABLED:
+            from google_sheets import toSheets
+
+            toSheets.save_notes_to_google_sheets(
+                main.GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE,
+                main.GOOGLE_SHEETS_SPREADSHEET_ID,
+                main.GOOGLE_SHEETS_WORKSHEET_NAME,
+                notes,
+                progress_callback=state.progress_callback,
+            )
+
+        state.status = "done"
+        state._push_event("done", {"notes_count": len(notes)})
+
+    except Exception as e:
+        state.status = "error"
+        state._push_event("error", {"message": str(e)})
+        traceback.print_exc()

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,0 +1,203 @@
+/* ============================================================
+   kindle2notion web – frontend controller
+   SSE client, 2FA modal, progress updates, screen transitions
+   ============================================================ */
+
+(function () {
+  "use strict";
+
+  // ---- DOM refs ----
+  var screens = {
+    start:    document.getElementById("screen-start"),
+    progress: document.getElementById("screen-progress"),
+    done:     document.getElementById("screen-done"),
+    error:    document.getElementById("screen-error"),
+  };
+
+  var btnStart   = document.getElementById("btn-start");
+  var btnRestart = document.getElementById("btn-restart");
+  var btnRetry   = document.getElementById("btn-retry");
+  var inputBooks = document.getElementById("max-books");
+
+  var modal2fa   = document.getElementById("modal-2fa");
+  var input2fa   = document.getElementById("input-2fa");
+  var btn2fa     = document.getElementById("btn-2fa");
+
+  var globalStatus = document.getElementById("global-status");
+  var doneMessage  = document.getElementById("done-message");
+  var errorMessage = document.getElementById("error-message");
+
+  var eventSource = null;
+
+  // ---- Screen management ----
+  function showScreen(name) {
+    Object.keys(screens).forEach(function (key) {
+      screens[key].classList.toggle("active", key === name);
+    });
+  }
+
+  // ---- Progress helpers ----
+  function updatePhase(phase, current, total, message) {
+    var bar    = document.getElementById("bar-" + phase);
+    var count  = document.getElementById("count-" + phase);
+    var status = document.getElementById("status-" + phase);
+    if (!bar) return;
+
+    if (total > 0) {
+      bar.style.width = ((current / total) * 100).toFixed(1) + "%";
+      count.textContent = current + " / " + total;
+    }
+    status.textContent = message;
+    globalStatus.textContent = message;
+  }
+
+  function resetProgress() {
+    ["scrape", "notion", "sheets"].forEach(function (phase) {
+      var bar    = document.getElementById("bar-" + phase);
+      var count  = document.getElementById("count-" + phase);
+      var status = document.getElementById("status-" + phase);
+      if (bar) bar.style.width = "0%";
+      if (count) count.textContent = "";
+      if (status) status.textContent = "";
+    });
+    globalStatus.textContent = "ログインしています...";
+    globalStatus.className = "status-bar";
+  }
+
+  // ---- SSE ----
+  function connectSSE() {
+    if (eventSource) { eventSource.close(); }
+    eventSource = new EventSource("/api/events");
+
+    eventSource.addEventListener("started", function () {
+      // pipeline started — already on progress screen
+    });
+
+    eventSource.addEventListener("progress", function (e) {
+      var d = JSON.parse(e.data);
+      updatePhase(d.phase, d.current, d.total, d.message);
+    });
+
+    eventSource.addEventListener("2fa_required", function () {
+      modal2fa.classList.add("active");
+      input2fa.value = "";
+      input2fa.focus();
+    });
+
+    eventSource.addEventListener("done", function (e) {
+      var d = JSON.parse(e.data);
+      // Set all bars to 100 %
+      ["scrape", "notion", "sheets"].forEach(function (phase) {
+        var bar = document.getElementById("bar-" + phase);
+        if (bar) bar.style.width = "100%";
+      });
+      globalStatus.textContent = "完了しました";
+      globalStatus.className = "status-bar done";
+
+      doneMessage.textContent = d.notes_count + " 件のハイライトを処理しました。";
+      showScreen("done");
+      closeSSE();
+    });
+
+    eventSource.addEventListener("error", function (e) {
+      // SSE spec fires generic "error" on connection loss — check if it's ours
+      if (e.data) {
+        var d = JSON.parse(e.data);
+        errorMessage.textContent = d.message;
+        showScreen("error");
+        closeSSE();
+      }
+    });
+
+    eventSource.onerror = function () {
+      // Connection lost — try to reconnect after a short delay
+      // (The browser's built-in reconnect may also fire)
+    };
+  }
+
+  function closeSSE() {
+    if (eventSource) { eventSource.close(); eventSource = null; }
+  }
+
+  // ---- Start pipeline ----
+  function startPipeline() {
+    var value = inputBooks.value.trim();
+    var body = {};
+    if (value && parseInt(value, 10) > 0) {
+      body.max_books = parseInt(value, 10);
+    }
+
+    btnStart.disabled = true;
+    btnStart.textContent = "開始中...";
+
+    fetch("/api/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
+      .then(function (res) {
+        if (!res.ok) {
+          return res.json().then(function (d) { throw new Error(d.error || "Failed to start"); });
+        }
+        resetProgress();
+        showScreen("progress");
+        connectSSE();
+      })
+      .catch(function (err) {
+        alert(err.message);
+      })
+      .finally(function () {
+        btnStart.disabled = false;
+        btnStart.textContent = "同期を開始";
+      });
+  }
+
+  // ---- Submit 2FA ----
+  function submit2FA() {
+    var code = input2fa.value.trim().replace(/\s/g, "");
+    if (!code) return;
+
+    btn2fa.disabled = true;
+    btn2fa.textContent = "送信中...";
+
+    fetch("/api/2fa", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code: code }),
+    })
+      .then(function (res) {
+        if (!res.ok) {
+          return res.json().then(function (d) { throw new Error(d.error || "Failed"); });
+        }
+        modal2fa.classList.remove("active");
+      })
+      .catch(function (err) {
+        alert(err.message);
+      })
+      .finally(function () {
+        btn2fa.disabled = false;
+        btn2fa.textContent = "コードを送信";
+      });
+  }
+
+  // ---- Go back to start ----
+  function goToStart() {
+    closeSSE();
+    inputBooks.value = "";
+    showScreen("start");
+  }
+
+  // ---- Bind events ----
+  btnStart.addEventListener("click", startPipeline);
+  btnRestart.addEventListener("click", goToStart);
+  btnRetry.addEventListener("click", goToStart);
+  btn2fa.addEventListener("click", submit2FA);
+
+  input2fa.addEventListener("keydown", function (e) {
+    if (e.key === "Enter") submit2FA();
+  });
+
+  inputBooks.addEventListener("keydown", function (e) {
+    if (e.key === "Enter") startPipeline();
+  });
+})();

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1,0 +1,267 @@
+/* ============================================================
+   kindle2notion web – mobile-first responsive styles
+   Color palette matches the existing tkinter GUI
+   ============================================================ */
+
+:root {
+  --bg:            #edf4ff;
+  --card-bg:       #ffffff;
+  --card-edge:     #d8e6f5;
+  --header-bg:     #f8fbff;
+  --surface-bg:    #f4f8fc;
+  --text-primary:  #0f172a;
+  --text-secondary:#475569;
+  --text-subtle:   #64748b;
+  --accent:        #0ea5e9;
+  --accent-hover:  #0284c7;
+  --accent-soft:   #e0f2fe;
+  --danger:        #dc2626;
+  --danger-soft:   #fee2e2;
+  --neutral-border:#cbd5e1;
+  --secondary-bg:  #eef4fb;
+  --button-text:   #ffffff;
+  --success:       #16a34a;
+  --success-soft:  #dcfce7;
+}
+
+*,
+*::before,
+*::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html {
+  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  font-family: "Yu Gothic UI", "Hiragino Sans", "Noto Sans JP", system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text-primary);
+  min-height: 100dvh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 16px;
+}
+
+.container { width: 100%; max-width: 480px; }
+
+/* ---- Screens ---- */
+.screen { display: none; }
+.screen.active { display: block; }
+
+/* ---- Card ---- */
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-edge);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0,0,0,.06);
+}
+
+.card-header {
+  background: var(--header-bg);
+  padding: 20px 20px 16px;
+}
+
+.card-body { padding: 20px; }
+
+/* ---- Badge ---- */
+.badge {
+  display: inline-block;
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+  font-size: .75rem;
+  font-weight: 700;
+  padding: 4px 10px;
+  border-radius: 4px;
+  letter-spacing: .04em;
+}
+
+.badge-done {
+  background: var(--success-soft);
+  color: var(--success);
+}
+
+.badge-error {
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+/* ---- Typography ---- */
+h1 {
+  font-size: 1.35rem;
+  font-weight: 700;
+  margin-top: 12px;
+}
+
+.subtitle {
+  color: var(--text-secondary);
+  font-size: .875rem;
+  margin-top: 4px;
+}
+
+label {
+  display: block;
+  font-size: .875rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.helper {
+  color: var(--text-subtle);
+  font-size: .8rem;
+  margin-top: 8px;
+  background: var(--secondary-bg);
+  padding: 8px 12px;
+  border-radius: 6px;
+}
+
+/* ---- Input ---- */
+input[type="number"],
+input[type="text"] {
+  width: 100%;
+  padding: 12px 14px;
+  font-size: 1rem;
+  border: 1px solid var(--neutral-border);
+  border-radius: 8px;
+  background: var(--surface-bg);
+  color: var(--text-primary);
+  outline: none;
+  transition: border-color .15s;
+  -webkit-appearance: none;
+}
+
+input:focus {
+  border-color: var(--accent);
+}
+
+#input-2fa {
+  font-family: "Consolas", "SF Mono", monospace;
+  font-size: 1.4rem;
+  font-weight: 700;
+  text-align: center;
+  letter-spacing: .15em;
+}
+
+/* ---- Buttons ---- */
+.btn-primary {
+  display: block;
+  width: 100%;
+  padding: 14px;
+  margin-top: 16px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--button-text);
+  background: var(--accent);
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background .15s;
+  -webkit-appearance: none;
+  min-height: 48px;
+}
+
+.btn-primary:active {
+  background: var(--accent-hover);
+}
+
+/* ---- Progress phases ---- */
+.phase { margin-bottom: 16px; }
+
+.phase-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 6px;
+}
+
+.phase-label {
+  font-size: .875rem;
+  font-weight: 600;
+}
+
+.phase-count {
+  font-size: .8rem;
+  color: var(--text-subtle);
+}
+
+.progress-track {
+  width: 100%;
+  height: 8px;
+  background: var(--secondary-bg);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  width: 0%;
+  background: var(--accent);
+  border-radius: 4px;
+  transition: width .3s ease;
+}
+
+.phase-status {
+  font-size: .8rem;
+  color: var(--text-subtle);
+  margin-top: 4px;
+  min-height: 1.2em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ---- Status bar ---- */
+.status-bar {
+  padding: 12px 20px;
+  background: var(--secondary-bg);
+  color: var(--text-secondary);
+  font-size: .85rem;
+  border-top: 1px solid var(--card-edge);
+}
+
+.status-bar.done {
+  background: var(--success-soft);
+  color: var(--success);
+}
+
+.status-bar.error {
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+/* ---- Done / Error headers ---- */
+.done-header { background: var(--success-soft); }
+.done-header h1 { color: var(--success); }
+
+.error-header { background: var(--danger-soft); }
+.error-header h1 { color: var(--danger); }
+.error-text { color: var(--danger); word-break: break-word; }
+
+/* ---- 2FA Modal ---- */
+.modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0,0,0,.45);
+  padding: 16px;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal.active {
+  display: flex;
+}
+
+.modal-content {
+  width: 100%;
+  max-width: 420px;
+}
+
+/* ---- Responsive tweaks ---- */
+@media (min-width: 600px) {
+  body { padding: 32px; align-items: center; }
+  h1 { font-size: 1.5rem; }
+}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kindle Highlights Sync</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <div class="container">
+
+    <!-- ===== Start Screen ===== -->
+    <div id="screen-start" class="screen active">
+      <div class="card">
+        <div class="card-header">
+          <span class="badge">KINDLE SYNC</span>
+          <h1>Kindleハイライト同期</h1>
+          <p class="subtitle">Kindle → Notion / Google Sheets</p>
+        </div>
+        <div class="card-body">
+          <label for="max-books">取得する書籍数</label>
+          <input id="max-books" type="number" min="1" placeholder="空欄 = すべて" inputmode="numeric">
+          <p class="helper">空欄のまま開始すると、すべての書籍を対象にします。</p>
+          <button id="btn-start" class="btn-primary">同期を開始</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== Progress Screen ===== -->
+    <div id="screen-progress" class="screen">
+      <div class="card">
+        <div class="card-header">
+          <span class="badge">SYNC IN PROGRESS</span>
+          <h1>同期中...</h1>
+          <p class="subtitle">進捗状況をリアルタイムで表示します</p>
+        </div>
+        <div class="card-body">
+          <div class="phase" id="phase-scrape">
+            <div class="phase-top">
+              <span class="phase-label">スクレイピング</span>
+              <span class="phase-count" id="count-scrape"></span>
+            </div>
+            <div class="progress-track"><div class="progress-bar" id="bar-scrape"></div></div>
+            <p class="phase-status" id="status-scrape"></p>
+          </div>
+
+          <div class="phase" id="phase-notion">
+            <div class="phase-top">
+              <span class="phase-label">Notionへ保存</span>
+              <span class="phase-count" id="count-notion"></span>
+            </div>
+            <div class="progress-track"><div class="progress-bar" id="bar-notion"></div></div>
+            <p class="phase-status" id="status-notion"></p>
+          </div>
+
+          <div class="phase" id="phase-sheets">
+            <div class="phase-top">
+              <span class="phase-label">Google Sheetsへ保存</span>
+              <span class="phase-count" id="count-sheets"></span>
+            </div>
+            <div class="progress-track"><div class="progress-bar" id="bar-sheets"></div></div>
+            <p class="phase-status" id="status-sheets"></p>
+          </div>
+        </div>
+        <div class="status-bar" id="global-status">ログインしています...</div>
+      </div>
+    </div>
+
+    <!-- ===== Done Screen ===== -->
+    <div id="screen-done" class="screen">
+      <div class="card">
+        <div class="card-header done-header">
+          <span class="badge badge-done">COMPLETE</span>
+          <h1>同期完了</h1>
+          <p class="subtitle" id="done-message"></p>
+        </div>
+        <div class="card-body">
+          <button id="btn-restart" class="btn-primary">新しい同期を開始</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== Error Screen ===== -->
+    <div id="screen-error" class="screen">
+      <div class="card">
+        <div class="card-header error-header">
+          <span class="badge badge-error">ERROR</span>
+          <h1>エラーが発生しました</h1>
+          <p class="subtitle error-text" id="error-message"></p>
+        </div>
+        <div class="card-body">
+          <button id="btn-retry" class="btn-primary">もう一度試す</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== 2FA Modal ===== -->
+    <div id="modal-2fa" class="modal">
+      <div class="modal-content card">
+        <div class="card-header">
+          <span class="badge">SECURITY CHECK</span>
+          <h1>二段階認証</h1>
+          <p class="subtitle">Amazonの認証コードを入力してください</p>
+        </div>
+        <div class="card-body">
+          <label for="input-2fa">認証コード</label>
+          <input id="input-2fa" type="text" inputmode="numeric" autocomplete="one-time-code" placeholder="123456">
+          <p class="helper">メールや認証アプリに表示されたコードを入力してください。</p>
+          <button id="btn-2fa" class="btn-primary">コードを送信</button>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/web_main.py
+++ b/web_main.py
@@ -1,0 +1,14 @@
+"""Entry point for the kindle2notion web interface.
+
+Usage:
+    python web_main.py
+
+Access from any device on the same network at http://<server-ip>:5000
+"""
+
+from web.app import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, threaded=True)


### PR DESCRIPTION
Introduces a Flask-based web UI that replaces the tkinter GUI when
accessed via browser, enabling the full pipeline (scrape → Notion →
Google Sheets) to be triggered from a mobile phone.

Key changes:
- amazon/login.py: injectable two_factor_callback (backward compatible)
- main.py: extracted load_config(), added headless_login parameter
- New web/ module: Flask app with SSE progress streaming, 2FA modal,
  HTTP Basic Auth, and mobile-first responsive design
- Entry point: python web_main.py (serves on 0.0.0.0:5000)

https://claude.ai/code/session_016jF5m1UTeRiAyqZpvRvvUt