### PR TITLE
Add VPS deployment guide and GitHub Actions auto-deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy to VPS
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-vps
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          port: ${{ secrets.VPS_PORT || 22 }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            cd /opt/kindle2notion
+            git fetch --all --prune
+            git reset --hard origin/main
+            .venv/bin/pip install --upgrade pip
+            .venv/bin/pip install -r requirements/requirements.txt
+            sudo /bin/systemctl restart kindle2notion-web.service
+            sudo /bin/systemctl status kindle2notion-web.service --no-pager

--- a/README.md
+++ b/README.md
@@ -173,6 +173,30 @@ http://<server-ip>:5000
 - `WEB_USERNAME` と `WEB_PASSWORD` を設定すると Basic 認証が有効になります
 - Web 版でも 2 段階認証コードを画面から入力できます
 
+### 外出先からアクセスする (VPS デプロイ)
+
+同じ Wi-Fi 外からスマホで利用したい場合は、無料枠のクラウド VPS に常駐させ、Caddy (自動 HTTPS) + DuckDNS (無料サブドメイン) 経由で公開できます。GitHub Actions を使って `main` に push するだけで自動デプロイされる構成です。
+
+手順とファイル:
+
+- 詳細ガイド: [`deploy/README.md`](deploy/README.md)
+- 構成ファイル一式: `deploy/` と `.github/workflows/deploy.yml`
+
+外部公開する場合は **必ず `WEB_USERNAME` / `WEB_PASSWORD` を設定**してください (未設定だと認証なしで誰でもアクセス可能)。
+
+## 手動で行う必要がある設定 (外部公開デプロイ向け)
+
+VPS へのデプロイには、スクリプトで自動化できない手動操作が 8 つあります。詳細な手順は [`deploy/README.md`](deploy/README.md) を参照してください。ここには必要な項目の一覧のみを掲載します。
+
+1. **クラウド VPS のアカウント作成とインスタンス起動** — Oracle Cloud Always Free (Ampere A1) または GCP e2-micro を選択し、Ubuntu 24.04 LTS でパブリック IP を確保する
+2. **DuckDNS のサブドメイン取得** — 無料サブドメインを予約し、発行された **トークン** をメモする
+3. **SSH 鍵ペアの生成と VPS への登録** — `ssh-keygen` で鍵を作り公開鍵を VPS に配置、パスワード認証と root ログインを無効化する
+4. **VPS 上での初回セットアップ** — リポジトリを `/opt/kindle2notion` に clone し `deploy/setup.sh` を実行、DuckDNS トークン配置と `Caddyfile` のドメイン書き換えを行う
+5. **`config/KEYS.env` の作成 (VPS 上のみ、Git には含めない)** — Amazon / Notion / (任意) Google Sheets の資格情報に加え、**`WEB_USERNAME`** と **`WEB_PASSWORD`** (長いランダム文字列)、`WEB_HOST=127.0.0.1` を記入する
+6. **Notion / Amazon / Google シートの各種資格情報の取得** — 上記「セットアップ」セクションを参照しつつ、それぞれのアカウント情報と API キーを準備する
+7. **GitHub リポジトリの Secrets 登録** — `VPS_HOST` / `VPS_USER` / `VPS_SSH_KEY` (必要なら `VPS_PORT`) をリポジトリの Actions Secrets に登録する
+8. **初回動作確認** — `systemctl start kindle2notion-web` でサービスを起動し、スマホのモバイル回線から DuckDNS の URL にアクセスして Basic 認証とパイプライン動作を確認する
+
 ## テスト
 
 ```bash

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,26 @@
+# Caddy reverse proxy for kindle2notion Web UI.
+# Replace `kindle2notion-xxx.duckdns.org` with your own domain before using.
+
+kindle2notion-xxx.duckdns.org {
+	encode zstd gzip
+
+	reverse_proxy 127.0.0.1:5000 {
+		# SSE (/api/events) needs streaming without buffering.
+		flush_interval -1
+		transport http {
+			read_timeout 1h
+			write_timeout 1h
+		}
+	}
+
+	header {
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		X-Content-Type-Options "nosniff"
+		Referrer-Policy "no-referrer"
+	}
+
+	log {
+		output file /var/log/caddy/kindle2notion.log
+		format console
+	}
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,173 @@
+# 外出先からアクセスする (VPS デプロイ)
+
+自宅の Wi-Fi 外からでもスマホで Web UI を操作できるようにするための構成と手順です。  
+無料枠のクラウド VPS 上で Flask を常駐させ、Caddy (自動 HTTPS) + DuckDNS (無料サブドメイン) 経由で公開し、GitHub Actions で自動デプロイします。
+
+## 構成
+
+```
+スマホ ──HTTPS──▶ DuckDNS サブドメイン
+                 │
+                 ▼
+        ┌────────── VPS (Ubuntu 24.04) ──────────┐
+        │  Caddy 80/443 ─▶ Flask 127.0.0.1:5000  │
+        │         ↑ Let's Encrypt 自動更新        │
+        │  systemd: kindle2notion-web.service    │
+        │    └─ python web_main.py               │
+        │                                        │
+        │  Basic 認証 (WEB_USERNAME / PASSWORD)   │
+        │  ufw: 22 / 80 / 443 のみ                │
+        └────────────────────────────────────────┘
+                 ▲
+                 │ GitHub Actions (push → SSH → git pull + restart)
+        GitHub  ─┘
+```
+
+## 手動で行う必要がある設定
+
+このデプロイでは、以下の 8 項目はユーザー自身による手動操作が必要です。セットアップ開始前にすべて準備することを推奨します。
+
+### 1. クラウド VPS のアカウント作成とインスタンス起動
+
+- [Oracle Cloud Always Free (Ampere A1)](https://www.oracle.com/cloud/free/) — 推奨 (1-4 vCPU / 最大 24 GB RAM が無期限無料)
+- または [GCP e2-micro Always Free](https://cloud.google.com/free) (1 vCPU / 1 GB RAM)
+- OS は **Ubuntu 24.04 LTS** を選択
+- パブリック IP アドレスをメモしておく
+
+### 2. DuckDNS のサブドメイン取得
+
+- https://www.duckdns.org/ に GitHub / Google / Twitter などのアカウントでログイン
+- 任意のサブドメインを登録 (例: `kindle2notion-yourname.duckdns.org`)
+- トップページに表示される **トークン** (`xxxxxxxx-xxxx-...`) をメモ
+
+### 3. SSH 鍵ペアの生成と VPS への登録
+
+```bash
+ssh-keygen -t ed25519 -f ~/.ssh/kindle2notion_vps -C "kindle2notion-deploy"
+ssh-copy-id -i ~/.ssh/kindle2notion_vps.pub <USER>@<VPS_IP>
+```
+
+VPS 側で `/etc/ssh/sshd_config` を編集し、次を無効化:
+
+- `PasswordAuthentication no`
+- `PermitRootLogin no`
+
+### 4. VPS 上での初回セットアップ
+
+```bash
+sudo git clone https://github.com/tabear25/kindle2notion.git /opt/kindle2notion
+sudo bash /opt/kindle2notion/deploy/setup.sh
+```
+
+セットアップ後に、下記を自分の環境に合わせて書き換え:
+
+```bash
+# DuckDNS トークンとサブドメイン名を配置
+echo "<YOUR_DUCKDNS_TOKEN>"   | sudo tee /etc/duckdns/token  >/dev/null
+echo "kindle2notion-yourname" | sudo tee /etc/duckdns/domain >/dev/null
+sudo chmod 600 /etc/duckdns/token /etc/duckdns/domain
+
+# Caddyfile のドメイン名を書き換え
+sudo sed -i 's/kindle2notion-xxx.duckdns.org/kindle2notion-yourname.duckdns.org/' /etc/caddy/Caddyfile
+
+# DuckDNS 初回更新 → Caddy 起動
+sudo /usr/local/bin/duckdns-update
+sudo systemctl restart caddy
+```
+
+### 5. `config/KEYS.env` の作成 (VPS 上のみ、Git には含めない)
+
+`/opt/kindle2notion/config/KEYS.env` を作成:
+
+```env
+AMAZON_EMAIL=<your amazon email>
+AMAZON_PASSWORD=<your amazon password>
+
+NOTION_API_KEY=<your notion integration secret>
+NOTION_DATABASE_ID=<your database id>
+
+# 任意: Google Sheets を使う場合
+GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE=/opt/kindle2notion/config/service-account.json
+GOOGLE_SHEETS_SPREADSHEET_ID=<your spreadsheet id>
+GOOGLE_SHEETS_WORKSHEET_NAME=Sheet1
+
+# 必須: 外部公開時の Basic 認証
+WEB_USERNAME=<好きなユーザー名>
+WEB_PASSWORD=<openssl rand -base64 32 などで生成した長いパスワード>
+```
+
+ファイル権限を絞っておく:
+
+```bash
+sudo chown kindle2notion:kindle2notion /opt/kindle2notion/config/KEYS.env
+sudo chmod 600 /opt/kindle2notion/config/KEYS.env
+```
+
+### 6. Notion / Amazon / Google シートの各種資格情報の取得
+
+メインの `README.md` (リポジトリルート) の「セットアップ」を参照:
+
+- Notion Integration の作成とデータベース共有
+- Amazon の Kindle Notebook にアクセス可能なアカウント
+- (任意) Google Cloud の Service Account + JSON 鍵
+
+### 7. GitHub リポジトリの Secrets 登録
+
+リポジトリの **Settings → Secrets and variables → Actions** に以下を登録:
+
+| Secret 名 | 値 |
+|-----------|-----|
+| `VPS_HOST` | VPS の IP または DuckDNS ドメイン |
+| `VPS_USER` | SSH ログインに使う VPS 上のユーザー名 |
+| `VPS_SSH_KEY` | 手順 3 で生成した **秘密鍵** `~/.ssh/kindle2notion_vps` の中身全部 |
+| `VPS_PORT` | (任意) SSH ポート。省略時は 22 |
+
+### 8. 初回動作確認
+
+```bash
+sudo systemctl start kindle2notion-web
+sudo systemctl status kindle2notion-web
+```
+
+- スマホを **モバイル回線 (4G/5G)** に切り替え、自宅 Wi-Fi を切る
+- ブラウザで `https://kindle2notion-yourname.duckdns.org/` を開く
+- Basic 認証 (手順 5 の `WEB_USERNAME` / `WEB_PASSWORD`) でログインできること
+- パイプラインを 1 回走らせ、2 段階認証コード入力まで問題なく動くこと
+
+## 自動デプロイの流れ
+
+`main` ブランチへの push をトリガに `.github/workflows/deploy.yml` が起動し、VPS へ SSH して以下を実行します。
+
+```bash
+cd /opt/kindle2notion
+git fetch --all
+git reset --hard origin/main
+.venv/bin/pip install -r requirements/requirements.txt
+sudo systemctl restart kindle2notion-web
+```
+
+## トラブルシュート
+
+### Caddy が証明書を取得できない
+
+- DuckDNS の A レコードが VPS の IP を指しているか: `dig +short kindle2notion-yourname.duckdns.org`
+- 80 番 / 443 番が ufw で開いているか: `sudo ufw status`
+- ログ: `sudo journalctl -u caddy -n 200`
+
+### SSE (/api/events) の進捗が途中で止まる
+
+- `Caddyfile` の `flush_interval -1` が設定されているか確認
+- 間に別のリバースプロキシ (Cloudflare proxy など) を挟む場合は streaming / buffering 設定も要調整
+
+### Playwright が起動しない
+
+```bash
+sudo -u kindle2notion /opt/kindle2notion/.venv/bin/python -m playwright install chromium
+sudo /opt/kindle2notion/.venv/bin/python -m playwright install-deps chromium
+```
+
+### systemd でログを見る
+
+```bash
+sudo journalctl -u kindle2notion-web -f
+```

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Initial provisioning script for an Ubuntu 24.04 VPS.
+# Run as root on a freshly created instance.
+#
+# Usage:
+#   sudo bash deploy/setup.sh
+#
+# Expects the repository to be cloned at /opt/kindle2notion beforehand.
+
+set -euo pipefail
+
+APP_DIR="/opt/kindle2notion"
+APP_USER="kindle2notion"
+DUCKDNS_DIR="/etc/duckdns"
+SERVICE_NAME="kindle2notion-web"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+	echo "This script must be run as root (use sudo)." >&2
+	exit 1
+fi
+
+if [[ ! -d "${APP_DIR}" ]]; then
+	echo "Repository is not present at ${APP_DIR}." >&2
+	echo "Clone it first, e.g.:  sudo git clone <repo-url> ${APP_DIR}" >&2
+	exit 1
+fi
+
+echo "==> Installing system packages"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y \
+	ca-certificates \
+	curl \
+	debian-keyring \
+	debian-archive-keyring \
+	apt-transport-https \
+	git \
+	ufw \
+	fail2ban \
+	python3 \
+	python3-venv \
+	python3-pip \
+	cron
+
+echo "==> Installing Caddy"
+if ! command -v caddy >/dev/null 2>&1; then
+	curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+		| gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+	curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+		| tee /etc/apt/sources.list.d/caddy-stable.list >/dev/null
+	apt-get update
+	apt-get install -y caddy
+fi
+
+echo "==> Creating application user"
+if ! id "${APP_USER}" >/dev/null 2>&1; then
+	useradd --system --create-home --home-dir "/home/${APP_USER}" --shell /usr/sbin/nologin "${APP_USER}"
+fi
+chown -R "${APP_USER}:${APP_USER}" "${APP_DIR}"
+
+echo "==> Creating Python virtualenv"
+sudo -u "${APP_USER}" python3 -m venv "${APP_DIR}/.venv"
+sudo -u "${APP_USER}" "${APP_DIR}/.venv/bin/pip" install --upgrade pip
+sudo -u "${APP_USER}" "${APP_DIR}/.venv/bin/pip" install -r "${APP_DIR}/requirements/requirements.txt"
+
+echo "==> Installing Playwright system dependencies"
+sudo -u "${APP_USER}" "${APP_DIR}/.venv/bin/python" -m playwright install-deps chromium || \
+	"${APP_DIR}/.venv/bin/python" -m playwright install-deps chromium
+
+echo "==> Installing Playwright Chromium for the app user"
+sudo -u "${APP_USER}" \
+	PLAYWRIGHT_BROWSERS_PATH="${APP_DIR}/.cache/ms-playwright" \
+	"${APP_DIR}/.venv/bin/python" -m playwright install chromium
+
+echo "==> Installing systemd service"
+install -m 0644 "${APP_DIR}/deploy/systemd/${SERVICE_NAME}.service" \
+	"/etc/systemd/system/${SERVICE_NAME}.service"
+systemctl daemon-reload
+systemctl enable "${SERVICE_NAME}.service"
+
+echo "==> Installing Caddyfile"
+install -m 0644 "${APP_DIR}/deploy/Caddyfile" /etc/caddy/Caddyfile
+mkdir -p /var/log/caddy
+chown -R caddy:caddy /var/log/caddy
+echo "Remember to edit /etc/caddy/Caddyfile and replace the placeholder domain."
+
+echo "==> Configuring ufw firewall"
+ufw --force reset
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow 22/tcp
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw --force enable
+
+echo "==> Configuring fail2ban"
+systemctl enable --now fail2ban
+
+echo "==> Setting up DuckDNS updater (token must be placed at ${DUCKDNS_DIR}/token)"
+mkdir -p "${DUCKDNS_DIR}"
+chmod 700 "${DUCKDNS_DIR}"
+cat >/usr/local/bin/duckdns-update <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+TOKEN_FILE="/etc/duckdns/token"
+DOMAIN_FILE="/etc/duckdns/domain"
+if [[ ! -f "${TOKEN_FILE}" || ! -f "${DOMAIN_FILE}" ]]; then
+	echo "DuckDNS token or domain file missing." >&2
+	exit 1
+fi
+TOKEN="$(cat "${TOKEN_FILE}")"
+DOMAIN="$(cat "${DOMAIN_FILE}")"
+curl -fsS "https://www.duckdns.org/update?domains=${DOMAIN}&token=${TOKEN}&ip=" \
+	>/var/log/duckdns.log
+SCRIPT
+chmod 700 /usr/local/bin/duckdns-update
+
+cat >/etc/cron.d/duckdns <<'CRON'
+*/5 * * * * root /usr/local/bin/duckdns-update >/dev/null 2>&1
+CRON
+chmod 644 /etc/cron.d/duckdns
+
+echo "==> Allowing the kindle2notion user to restart the service without a password"
+cat >/etc/sudoers.d/kindle2notion <<SUDO
+${APP_USER} ALL=(root) NOPASSWD: /bin/systemctl restart ${SERVICE_NAME}.service, /bin/systemctl status ${SERVICE_NAME}.service
+SUDO
+chmod 440 /etc/sudoers.d/kindle2notion
+
+echo ""
+echo "Setup finished. Remaining manual steps:"
+echo "  1. Write your DuckDNS token to ${DUCKDNS_DIR}/token (chmod 600)"
+echo "  2. Write your DuckDNS subdomain (without .duckdns.org) to ${DUCKDNS_DIR}/domain"
+echo "  3. Edit /etc/caddy/Caddyfile and replace kindle2notion-xxx.duckdns.org"
+echo "  4. Create ${APP_DIR}/config/KEYS.env with the required secrets"
+echo "  5. systemctl start caddy && systemctl start ${SERVICE_NAME}"

--- a/deploy/systemd/kindle2notion-web.service
+++ b/deploy/systemd/kindle2notion-web.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=kindle2notion Web UI
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=kindle2notion
+Group=kindle2notion
+WorkingDirectory=/opt/kindle2notion
+EnvironmentFile=/opt/kindle2notion/config/KEYS.env
+Environment=WEB_HOST=127.0.0.1
+Environment=WEB_PORT=5000
+Environment=PLAYWRIGHT_BROWSERS_PATH=/opt/kindle2notion/.cache/ms-playwright
+ExecStart=/opt/kindle2notion/.venv/bin/python web_main.py
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+ReadWritePaths=/opt/kindle2notion
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

This PR adds a complete VPS deployment setup for running the kindle2notion Web UI on a cloud instance with automatic HTTPS, dynamic DNS, and CI/CD integration. Users can now access the application from outside their home network via a secure public URL.

## Key Changes

- **`deploy/README.md`** — Comprehensive deployment guide covering:
  - Architecture overview (VPS + Caddy + DuckDNS + GitHub Actions)
  - 8 manual setup steps (VPS provisioning, DuckDNS registration, SSH keys, initial configuration, secrets management, credential setup, GitHub Secrets, and verification)
  - Troubleshooting section for common issues (certificate acquisition, SSE streaming, Playwright, systemd logging)

- **`deploy/setup.sh`** — Automated provisioning script for Ubuntu 24.04 that:
  - Installs system dependencies (Python, Caddy, ufw, fail2ban, cron)
  - Creates dedicated `kindle2notion` system user
  - Sets up Python virtualenv and installs application dependencies
  - Installs Playwright system dependencies and Chromium browser
  - Configures systemd service for the Flask application
  - Sets up ufw firewall rules (SSH, HTTP, HTTPS only)
  - Configures fail2ban for security
  - Implements DuckDNS updater with 5-minute cron job
  - Grants passwordless sudo for service restart to the app user

- **`deploy/Caddyfile`** — Reverse proxy configuration providing:
  - Automatic HTTPS via Let's Encrypt
  - Streaming support for SSE endpoints (`/api/events`) with `flush_interval -1`
  - Security headers (HSTS, X-Content-Type-Options, Referrer-Policy)
  - Compression (zstd, gzip)
  - Structured logging to `/var/log/caddy/`

- **`deploy/systemd/kindle2notion-web.service`** — Systemd service unit that:
  - Runs Flask application as dedicated `kindle2notion` user
  - Loads secrets from `config/KEYS.env`
  - Configures Playwright browser cache location
  - Implements security hardening (PrivateTmp, ProtectSystem, ProtectHome)
  - Auto-restarts on failure with 5-second delay

- **`.github/workflows/deploy.yml`** — GitHub Actions workflow that:
  - Triggers on push to `main` branch or manual dispatch
  - Uses SSH to connect to VPS via GitHub Secrets
  - Pulls latest code, updates dependencies, and restarts the service
  - Prevents concurrent deployments with concurrency control

- **`README.md`** — Updated main README with:
  - New section linking to VPS deployment guide
  - Summary of 8 manual setup steps required for external deployment
  - Security reminder about `WEB_USERNAME`/`WEB_PASSWORD` for public access

## Notable Implementation Details

- **Security-first design**: Basic authentication required for external access, firewall restricted to SSH/HTTP/HTTPS, fail2ban enabled, systemd service runs with minimal privileges
- **Zero-cost infrastructure**: Uses Oracle Cloud Always Free (Ampere A1) or GCP e2-micro tier
- **Automatic certificate management**: Caddy handles Let's Encrypt renewal transparently
- **Dynamic DNS support**: DuckDNS updater runs every 5 minutes to handle changing IP addresses
- **Streaming-aware proxy**: Caddy configured with `flush_interval -1` to support real-time SSE progress updates
- **CI/CD integration**: Single `git push` to `main` triggers automatic deployment via GitHub Actions

https://claude.ai/code/session_01AMDwLs993ZtqdtUBRR5dUd