### PR TITLE
fix: pin notion-client to <2.6 to restore databases.query dedup

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv
 playwright
-notion-client
+notion-client>=2.0,<2.6
 nest-asyncio
 tqdm
 gspread


### PR DESCRIPTION
notion-client 2.6.0 removed the databases.query method (the Notion API
itself deprecated POST /v1/databases/{id}/query in favor of
data_sources/{id}/query). Without it, get_existing_note_keys silently
fails and the Notion writer can no longer skip already-present
highlights, risking duplicates on re-runs of the manual / Kindle paths.

Pinning to >=2.0,<2.6 keeps the existing code working while the
data_sources migration is tracked separately.

https://claude.ai/code/session_019NjuqYXSg8hCK33m3VLkyj