### PR TITLE
fix: NotebookLM split を1回で完走 + マニュアル追加をsplitまで接続

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -81,6 +81,12 @@ NOTION_DATABASE_ID=...
 GOOGLE_SHEETS_SERVICE_ACCOUNT_FILE=/path/to/service_account.json
 GOOGLE_SHEETS_SPREADSHEET_ID=...
  
+# Optional — destination folder for scripts/split_per_book.py (the NotebookLM
+# 50-file split). Set to the Drive folder ID that hosts the notebooklm/ subfolder
+# so `split_per_book --apply` needs no --parent-folder. Required when the master
+# spreadsheet's own parent can't be auto-resolved (My Drive root / trashed folder).
+NOTEBOOKLM_PARENT_FOLDER_ID=
+ 
 # Optional — Basic auth for the web UI (omit to disable auth)
 WEB_USERNAME=
 WEB_PASSWORD=
@@ -281,13 +287,15 @@ Contains two groups of helpers:
 - Index sheet columns: `book_id, title, volume, highlight_count, last_synced_at` (`volume` is the volume filename — a book→file lookup)
 - Filenames are fixed (no extension): index `<prefix>_index`, volumes `<prefix>_vol_01`..`<prefix>_vol_49`. Default prefix `k2n`.
 - Volumes + index are rewritten in full from the master every run (idempotent); books sorted by `book_id`, highlights by `highlight_id` for byte-stable output. Empty volumes are written header-only.
+- **Write throttling**: each volume rewrite is `clear()` + `update()` = 2 write requests, and a full run touches all 50 files (~100 requests), which exceeds the Sheets API's ~60-writes/min/user quota. `_write_volume()` paces each write (`WRITE_THROTTLE_SECONDS`) and retries on a 429 (`QUOTA_RETRY_WAIT_SECONDS` × `MAX_QUOTA_RETRIES`), so a single `--apply` completes all 50 files (~2 min) instead of dying around `k2n_vol_27` and leaving later volumes stale.
 - **Does not create new spreadsheet files.** Service accounts have 0 bytes of personal Drive storage, so creating files in "My Drive" fails with `storageQuotaExceeded`. The script writes only to spreadsheets that already exist in the target folder; missing files are reported as `[missing]`. Because the 50 filenames are fixed, the user creates the 50 empty Sheets **once** — new books afterwards need no new files.
 - Default subfolder is `notebooklm/` (was `per_book/`). Legacy `per_book/` one-file-per-book Sheets are **never** auto-deleted; the user retires them manually.
 - CLI flags:
   - `--apply`: actually write (default is dry-run)
   - `--folder <name>`: destination subfolder name (default: `notebooklm`)
   - `--prefix <str>`: filename prefix for volume/index files (default: `k2n`)
-  - `--parent-folder <FOLDER_ID>`: explicit Drive folder ID to host the destination subfolder. Required when the master spreadsheet lives in "My Drive" root (Drive API cannot resolve its parent for service-account-shared files at the root). Validated up-front via `_validate_parent_folder()`: must be an accessible folder with `canAddChildren=true`
+  - `--parent-folder <FOLDER_ID>`: explicit Drive folder ID to host the destination subfolder. Required when the master spreadsheet lives in "My Drive" root (Drive API cannot resolve its parent for service-account-shared files at the root) **or inside a trashed folder** (auto-detection then resolves to the trashed parent). Validated up-front via `_validate_parent_folder()`: must be an accessible folder with `canAddChildren=true`
+- **Parent-folder resolution order**: `--parent-folder` flag → `NOTEBOOKLM_PARENT_FOLDER_ID` env var (`PARENT_FOLDER_ENV_VAR`) → auto-detect from the master's own Drive parent. Set the env var in `config/KEYS.env` (the folder ID of the live folder that hosts `notebooklm/`) for a persistent setting so `--apply` needs no flag each run; the env var is also `_validate_parent_folder()`-checked.
 - Pure helpers (`safe_title_for_filename`, `volume_for_book_id`, `volume_filename`, `index_filename`, `all_target_filenames`, `group_books_by_volume`, `volume_rows`, `index_rows`, `group_highlights_by_book`) are covered by `test/test_split_per_book.py`; runtime deps (`gspread`, `google-auth`) are guarded so tests can import the module without them
  
 ### `scripts/add_manual_highlights.py`
@@ -426,4 +434,5 @@ The following are git-ignored and must not be committed:
 - `storage_state.json` is reused on the next run if it already exists (no explicit expiry logic).
 - The GUI requires a display server (X11/Wayland). Running headlessly in CI will fail unless a virtual display is provided.
 - Service accounts have **0 bytes of personal Drive storage**. They can edit files shared with them and create folders (0 bytes), but they cannot own new files in "My Drive" — Google rejects creation with `storageQuotaExceeded`. Workarounds: (a) Workspace Shared Drive, (b) OAuth user credentials, (c) pre-create files manually. `scripts/split_per_book.py` uses option (c).
-- For files in "My Drive" root that are shared with the service account (not owned), the Drive API may return an empty `parents` field. `scripts/split_per_book.py` handles this via the `--parent-folder` CLI flag.
+- For files in "My Drive" root that are shared with the service account (not owned), the Drive API may return an empty `parents` field. `scripts/split_per_book.py` handles this via the `--parent-folder` CLI flag or the `NOTEBOOKLM_PARENT_FOLDER_ID` env var.
+- A spreadsheet whose **parent folder was trashed** is still readable/writable by ID (the service account writes succeed), but it is invisible in the owner's normal Drive view and will be **permanently deleted** when the trash auto-purges (~30 days). If `01_books`/`02_highlights` writes "succeed" but the user can't see them, check the master's `trashed` flag via the Drive API (`files.get?fields=trashed,explicitlyTrashed,parents`). In that state, `split_per_book` auto-detection resolves the master's parent to the trashed folder, so set `NOTEBOOKLM_PARENT_FOLDER_ID` (or `--parent-folder`) to the live destination folder.

--- a/.claude/skills/adding-manual-highlights/SKILL.md
+++ b/.claude/skills/adding-manual-highlights/SKILL.md
@@ -184,7 +184,40 @@ only Notion is updated — relay that to the user.
 
 Optional flags: `--notion-only` / `--sheets-only` to target one destination.
 
-## Step 6 — Clean up
+## Step 6 — Propagate to the 50 NotebookLM sheets (Google Sheets only)
+
+`add_manual_highlights` writes only to the **master** (`01_books` /
+`02_highlights`), exactly like the Kindle scraper (`main.py`). But the user
+*reads* their highlights from the **50 fixed NotebookLM sheets**
+(`k2n_index` + `k2n_vol_01..49` in the `notebooklm/` folder), which are a
+**derived copy** produced by `scripts/split_per_book.py`. So a manual add is
+**not visible to the user until you run the split** — this is the step that was
+historically missing and made "I can't find it in Sheets" happen.
+
+After a successful `--apply` (and only if Google Sheets is configured), run:
+
+```bash
+py -m scripts.split_per_book --apply
+```
+
+- This reads the master and rewrites all 50 sheets (idempotent). The new book
+  lands in its pinned volume and the index row appears. It takes ~2 minutes:
+  writes are **paced** to respect the Sheets API's ~60-writes/min quota and
+  **retried on a 429**, so a single run now completes all 50 files (an
+  unthrottled run used to die around `k2n_vol_27`, leaving later volumes stale).
+- **Destination folder**: the script needs to know which Drive folder hosts the
+  `notebooklm/` subfolder. Preferred: the user sets `NOTEBOOKLM_PARENT_FOLDER_ID`
+  in `config/KEYS.env` once (the folder ID of the live `kindle2notion` folder);
+  then no flag is needed. Otherwise pass `--parent-folder <FOLDER_ID>`. (This is
+  required while the master spreadsheet's own parent can't be auto-resolved —
+  e.g. it sits in 'My Drive' root or inside a trashed folder.)
+- Preview first with a dry-run (drop `--apply`) if you want to show the user the
+  plan. Report honestly: if any file is `[missing]`, tell the user which 50-file
+  names to create once (the script lists them).
+- If Google Sheets is **not** configured, there is no 50-sheet set — skip this
+  step (Notion already holds the highlight).
+
+## Step 7 — Clean up
 
 Delete the temporary `*.json` input file after a successful run (it is
 git-ignored but leaving it around is untidy). Confirm to the user what was added.
@@ -204,7 +237,9 @@ git-ignored but leaving it around is untidy). Confirm to the user what was added
 
 Use this when you are in a **claude.ai/code cloud session** connected to this
 repo (typical "from my phone" case). It is just **Local mode with `python`**, so
-Steps 1–6 above apply verbatim — only the launcher changes (`py` → `python`).
+Steps 1–7 above apply verbatim — only the launcher changes (`py` → `python`).
+That includes Step 6 (`python -m scripts.split_per_book --apply`); set
+`NOTEBOOKLM_PARENT_FOLDER_ID` as a cloud env var so it needs no `--parent-folder`.
 
 One-time setup the user does in the cloud environment (relay these if they
 haven't; you cannot set them yourself):

--- a/scripts/split_per_book.py
+++ b/scripts/split_per_book.py
@@ -21,6 +21,12 @@ Usage::
     python -m scripts.split_per_book --apply           # actually write
     python -m scripts.split_per_book --apply --folder notebooklm
 
+Writes are paced (and retried on a per-minute 429) so a full 50-file ``--apply``
+completes in one run. If the master's own Drive parent cannot be auto-resolved
+(e.g. it sits in 'My Drive' root or inside a trashed folder), set the
+``NOTEBOOKLM_PARENT_FOLDER_ID`` env var (or pass ``--parent-folder``) so the
+destination folder is found without it.
+
 Design notes:
 
 - Uses the same Service Account credential as the rest of the pipeline.
@@ -43,9 +49,11 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import re
 import statistics
 import sys
+import time
 from pathlib import Path
 
 # Make the project root importable when run as ``python scripts/...``.
@@ -55,6 +63,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 # helpers without needing gspread / google-auth / nest_asyncio installed.
 try:
     import gspread  # type: ignore
+    from gspread.exceptions import APIError  # type: ignore
     from google.auth.transport.requests import AuthorizedSession  # type: ignore
     from google.oauth2.service_account import Credentials  # type: ignore
     from google_sheets.toSheets import BOOKS_SHEET, HIGHLIGHTS_SHEET, SCOPES  # noqa: E402
@@ -69,6 +78,21 @@ DRIVE_API = "https://www.googleapis.com/drive/v3"
 VOLUME_COUNT = 49
 DEFAULT_SUBFOLDER_NAME = "notebooklm"
 DEFAULT_FILENAME_PREFIX = "k2n"
+
+# Google Sheets caps writes at ~60 requests/min/user. Each volume rewrite is
+# clear()+update() = 2 write requests, and a full run touches all 50 files
+# (~100 requests), so an unthrottled ``--apply`` reliably trips a 429 partway
+# through and leaves the later volumes stale. Pace each write to stay under the
+# limit, and retry once the per-minute window resets (see ``_write_volume``).
+WRITE_THROTTLE_SECONDS = 2.5
+QUOTA_RETRY_WAIT_SECONDS = 60
+MAX_QUOTA_RETRIES = 5
+
+# Env var naming the Drive folder that hosts the ``notebooklm`` subfolder. Set
+# this when the master spreadsheet's own parent cannot be auto-resolved (e.g.
+# the master lives in 'My Drive' root, or has been moved into a trashed folder),
+# so ``--apply`` no longer needs the ``--parent-folder`` flag each run.
+PARENT_FOLDER_ENV_VAR = "NOTEBOOKLM_PARENT_FOLDER_ID"
 
 # Columns on each volume sheet. ``book_id`` + ``book_title`` make every row
 # self-describing so NotebookLM keeps book context even when one file holds
@@ -373,12 +397,34 @@ def _load_master(gc, spreadsheet_id: str) -> tuple[list[dict], list[dict]]:
 
 
 def _write_volume(gc, file_id: str, header_and_rows: list[list[str]]) -> None:
-    """Replace sheet 1 of ``file_id`` with the supplied rows."""
+    """Replace sheet 1 of ``file_id`` with the supplied rows.
+
+    Paces each write and retries on a per-minute write-quota error (HTTP 429)
+    so a full 50-file ``--apply`` completes in one run instead of dying partway
+    through and leaving the later volumes stale.
+    """
     sh = gc.open_by_key(file_id)
     ws = sh.sheet1
-    ws.clear()
-    if header_and_rows:
-        ws.update("A1", header_and_rows, value_input_option="RAW")
+    for attempt in range(MAX_QUOTA_RETRIES + 1):
+        try:
+            ws.clear()
+            if header_and_rows:
+                ws.update("A1", header_and_rows, value_input_option="RAW")
+            break
+        except APIError as e:
+            status = getattr(getattr(e, "response", None), "status_code", None)
+            if status == 429 and attempt < MAX_QUOTA_RETRIES:
+                print(
+                    f"  [quota] write-rate limit (429); waiting "
+                    f"{QUOTA_RETRY_WAIT_SECONDS}s then retrying "
+                    f"({attempt + 1}/{MAX_QUOTA_RETRIES})...",
+                    flush=True,
+                )
+                time.sleep(QUOTA_RETRY_WAIT_SECONDS)
+                continue
+            raise
+    if WRITE_THROTTLE_SECONDS:
+        time.sleep(WRITE_THROTTLE_SECONDS)
 
 
 def main_cli() -> int:
@@ -419,7 +465,9 @@ def main_cli() -> int:
             "Use this when the master spreadsheet lives in 'My Drive' root and "
             "the Drive API cannot determine its parent automatically. "
             "Find the ID in the folder's URL: "
-            "drive.google.com/drive/folders/<FOLDER_ID>"
+            "drive.google.com/drive/folders/<FOLDER_ID>. "
+            f"For a persistent setting, set the {PARENT_FOLDER_ENV_VAR} env var "
+            "instead (this flag overrides it)."
         ),
     )
     args = parser.parse_args()
@@ -444,10 +492,15 @@ def main_cli() -> int:
         f"prefix '{args.prefix}'"
     )
 
+    env_parent = os.environ.get(PARENT_FOLDER_ENV_VAR, "").strip()
     if args.parent_folder:
         parent_id = args.parent_folder
         _validate_parent_folder(drive, parent_id)
         print(f"[parent] folder id = {parent_id}  (from --parent-folder)")
+    elif env_parent:
+        parent_id = env_parent
+        _validate_parent_folder(drive, parent_id)
+        print(f"[parent] folder id = {parent_id}  (from ${PARENT_FOLDER_ENV_VAR})")
     else:
         parent_id = _get_parent_folder(drive, repo_main.GOOGLE_SHEETS_SPREADSHEET_ID)
         print(f"[parent] folder id = {parent_id}")


### PR DESCRIPTION
## 背景 / Why

ユーザーは Kindle 取り込みや手動追加したハイライトを、最終的に NotebookLM 用の **50分割シート**（`k2n_index` + `k2n_vol_01..49`）で読んでいる。これは `scripts/split_per_book.py` が master（`01_books`/`02_highlights`）から生成する派生物。

今回、以下2つの不具合で「追加したのに Sheets で見えない」状態が発生していた。

1. **`split_per_book.py` に書き込みスロットリングが無い** — 50ファイル × (clear+update) ≈ 100 write requests で Sheets API の 60 writes/min/user 上限を超え、`k2n_vol_27` あたりで 429 中断 → 後半の巻が慢性的に古いまま。
2. **手動追加フローに split 工程が無い** — `add_manual_highlights` は master にしか書かず、split を回さないと 50シートに反映されない（=ユーザーに見えない）。

## 変更 / What

- **`scripts/split_per_book.py`**
  - `_write_volume()` に書き込みペーシング（`WRITE_THROTTLE_SECONDS`）と 429 リトライ（`QUOTA_RETRY_WAIT_SECONDS` × `MAX_QUOTA_RETRIES`）を追加 → 1回の `--apply` で50ファイル完走。
  - 親フォルダ解決に `NOTEBOOKLM_PARENT_FOLDER_ID` 環境変数を追加。優先順位: `--parent-folder` フラグ > 環境変数 > master の親フォルダ自動検出。master の親が自動解決できない場合（My Drive ルート / ゴミ箱フォルダ内）でもフラグ無しで動く。
- **`.claude/skills/adding-manual-highlights/SKILL.md`**
  - **Step 6「split で50シートへ反映」を新設**。Cloud mode の参照も Steps 1–7 に更新。
- **`.claude/CLAUDE.md`**
  - スロットリング / 環境変数（KEYS.env サンプル含む） / ゴミ箱に入った master のデータ消失 gotcha を明文化。

## 検証 / Testing

- `test/test_split_per_book.py` の純粋関数テスト 22件すべてパス（挙動変更なし）。
- 修正後の `split_per_book --apply` を実機で1回流し、**50/50 ファイル完走・429ゼロ**を確認。
- 環境変数パス（`NOTEBOOKLM_PARENT_FOLDER_ID`）の dry-run / 実書き込み両方で動作確認。

## 補足 / Notes

- master `reading_note` が現在 Drive のゴミ箱フォルダ内にある状態は本PRの対象外（運用面の課題）。本PRはその状態でもフローが回るよう環境変数対応を入れている。データ保全のため master の救出は別途推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
